### PR TITLE
#17 option pannel chgmt de couleur

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -7,9 +7,8 @@
   margin-top: 5vh;
 }
 
-app-tools-panel, app-options-panel {
-  width: 120px;
-  height: 300px;
+app-tools-panel,
+app-options-panel {
 }
 
 app-tools-panel {
@@ -41,7 +40,6 @@ app-options-panel {
   color: #525252;
 }
 
-
 #header {
   position: absolute;
   top: 0;
@@ -64,7 +62,11 @@ app-header {
 }
 
 @media only screen and (max-width: 700px) {
-  #header, #footer, app-header, app-tools-panel, app-options-panel {
+  #header,
+  #footer,
+  app-header,
+  app-tools-panel,
+  app-options-panel {
     display: none;
   }
 
@@ -77,7 +79,11 @@ app-header {
 }
 
 @media only screen and (max-height: 400px) {
-  #header, #footer, app-header, app-tools-panel, app-options-panel {
+  #header,
+  #footer,
+  app-header,
+  app-tools-panel,
+  app-options-panel {
     display: none;
   }
 

--- a/src/app/components/drawing-board/drawing-board.component.ts
+++ b/src/app/components/drawing-board/drawing-board.component.ts
@@ -33,12 +33,14 @@ export class DrawingBoardComponent implements AfterViewInit {
     });
 
     this.headerService.listenFullScreen.subscribe(_ => {
-      this.isFullScreen = true;
+      this.canvasService.setFullScreen(true);
       this.canvasService.resize(this.canvas, this.canvasCtx);
     });
   }
 
-  isFullScreen = false;
+  get isFullScreen() {
+    return this.canvasService.isFullScreen;
+  }
 
   _canvasCtx: CanvasRenderingContext2D | undefined;
 
@@ -74,7 +76,7 @@ export class DrawingBoardComponent implements AfterViewInit {
 
   @HostListener('mousedown', ['$event.target'])
   onClick() {
-    this.isFullScreen = false;
+    this.canvasService.setFullScreen(false);
     this.canvasService.resize(this.canvas, this.canvasCtx);
   }
 }

--- a/src/app/components/options-panel/options-panel.component.html
+++ b/src/app/components/options-panel/options-panel.component.html
@@ -1,8 +1,8 @@
-<div class="option-panel">
-  <div
+<div class="option-panel" style="">
+  <!-- <div
     class="color-box"
     (click)="setColor('black')"
-    [ngStyle]="{ 'background-color': 'black' }"></div>
+    [ngStyle]="{ 'background-color': 'black' }"></div> -->
   <!-- <div
     class="color-box"
     (click)="setColor('silver')"
@@ -59,7 +59,7 @@
     class="color-box"
     (click)="setColor('teal')"
     [ngStyle]="{ 'background-color': 'teal' }"></div> -->
-  <div
+  <!-- <div
     class="color-box"
     (click)="setColor('aqua')"
     [ngStyle]="{ 'background-color': 'aqua' }"></div>
@@ -70,5 +70,36 @@
     max="50"
     step="1"
     [(ngModel)]="lineWidth"
-    (ngModelChange)="setLineWidth(lineWidth)" />
+    (ngModelChange)="setLineWidth(lineWidth)" /> -->
+
+  <!-- <div class="color-box" (click)="setColor('black')">
+    <div class="color-box-inner" 
+      [ngStyle]="{ 'background-color': 'black' }"
+    ></div>
+  </div> -->
+
+  <ng-container *ngFor="let color of colors">
+    <div
+      class="color-box"
+      (click)="setColor(color)"
+      [ngStyle]="
+        color === currentColor() ? { border: '#323232 solid 1px' } : {}
+      ">
+      <div
+        class="color-box-inner"
+        [ngStyle]="{ 'background-color': color }"></div>
+    </div>
+  </ng-container>
+
+  <div>
+    <input
+      style="width: 105px; color: red"
+      class="slider-line-width"
+      type="range"
+      min="1"
+      max="50"
+      step="1"
+      [(ngModel)]="lineWidth"
+      (ngModelChange)="setLineWidth(lineWidth)" />
+  </div>
 </div>

--- a/src/app/components/options-panel/options-panel.component.scss
+++ b/src/app/components/options-panel/options-panel.component.scss
@@ -1,7 +1,45 @@
-div {
+.option-panel {
   background-color: #424242;
   height: 100%;
   border-radius: 10px;
   -webkit-box-shadow: 0px 0px 9px 1px #000000;
   box-shadow: 0px 0px 9px 1px #000000;
+
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  width: 110px;
+  height: 270px;
+  max-width: 110px;
+  max-height: 290px;
+  padding-left: 5px;
+  padding-right: 5px;
+  padding-top: 15px;
+  padding-bottom: 15px;
+  align-content: flex-start;
+}
+
+.color-box {
+  height: 33px;
+  width: 33px;
+  background-color: #424242;
+  -webkit-box-shadow: 0px 0px 17px -8px #151414;
+  box-shadow: 0px 0px 17px -8px #151414;
+  // border: #323232 solid 0.5px;
+  border-radius: 5px;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.color-box:hover {
+  cursor: pointer;
+  border: #323232 solid 0.5px;
+}
+
+.color-box-inner {
+  height: 25px;
+  width: 25px;
+  border-radius: 50px;
 }

--- a/src/app/components/options-panel/options-panel.component.ts
+++ b/src/app/components/options-panel/options-panel.component.ts
@@ -10,6 +10,21 @@ export class OptionsPanelComponent {
   constructor(private drawingDataService: DrawingDataService) {}
   lineWidth = 2;
 
+  colors: string[] = [
+    'black',
+    'red',
+    'blue',
+    'green',
+    'yellow',
+    'orange',
+    'purple',
+    'brown',
+  ];
+
+  currentColor(): string {
+    return this.drawingDataService.getColor();
+  }
+
   setColor(color: string) {
     this.drawingDataService.setColor(color);
   }

--- a/src/app/components/tools-panel/tools-panel.component.scss
+++ b/src/app/components/tools-panel/tools-panel.component.scss
@@ -4,4 +4,9 @@ div {
   border-radius: 10px;
   -webkit-box-shadow: 0px 0px 9px 1px #000000;
   box-shadow: 0px 0px 9px 1px #000000;
+  width: 110px;
+  height: 290px;
+  max-width: 110px;
+  max-height: 290px;
+  padding: 5px;
 }

--- a/src/app/services/canvas.service.ts
+++ b/src/app/services/canvas.service.ts
@@ -11,6 +11,8 @@ export class CanvasService {
   private indexFormatBoard = 0;
   format: number = this.formatsBoard[this.indexFormatBoard];
 
+  isFullScreen = false;
+
   resize(
     canvas: HTMLCanvasElement,
     canvasCtx: CanvasRenderingContext2D,
@@ -40,7 +42,8 @@ export class CanvasService {
     // Resize the canvas
     if (
       window.innerWidth < this.minWidth ||
-      window.innerHeight < this.minHeight
+      window.innerHeight < this.minHeight ||
+      this.isFullScreen
     ) {
       canvas.width = window.innerWidth;
       canvas.height = window.innerHeight;
@@ -66,5 +69,9 @@ export class CanvasService {
 
   clear(canvas: HTMLCanvasElement, canvasCtx: CanvasRenderingContext2D) {
     canvasCtx.clearRect(0, 0, canvas.width, canvas.height);
+  }
+
+  setFullScreen(fullScreen: boolean) {
+    this.isFullScreen = fullScreen;
   }
 }


### PR DESCRIPTION
j'ai mis toutes les couleurs que j'ai trouvé ici https://www.w3.org/TR/css-color-3/ j'ai commenté toutes les couleurs sauf noir et aqua, en attendant le CSS changement de l'épaisseur du trait, slider qui va de 1 à 50 trois classes css à implémenter :
- option-panel = ce qui regroupe tout (jpense inutile mais bon)
- color-box = chaque div de couleur
- slider-line-width = le slider pr l'épaisseur du trait